### PR TITLE
Add support for python27-64bit

### DIFF
--- a/launcher_tool/__main__.py
+++ b/launcher_tool/__main__.py
@@ -71,10 +71,17 @@ def main():
 
     args = parser.parse_args()
 
+    is_64bits = sys.maxsize > 2**32  # recommended by docs.python.org "platform" module
     if (sys.version_info.major == 2 and not args.py3) or args.py2:
-        launcher_filename = 'launcher27.exe'
+        if args.bits64:
+            launcher_filename = 'launcher27-64.exe'
+        elif args.bits32:
+            launcher_filename = 'launcher27-32.exe'
+        elif is_64bits:
+            launcher_filename = 'launcher27-64.exe'
+        else:
+            launcher_filename = 'launcher27-32.exe'
     else:
-        is_64bits = sys.maxsize > 2**32  # recommended by docs.python.org "platform" module
         if args.bits64:
             launcher_filename = 'launcher3-64.exe'
         elif args.bits32:

--- a/launcher_tool/copy_launcher.py
+++ b/launcher_tool/copy_launcher.py
@@ -16,9 +16,10 @@ import sys
 def copy_launcher(fileobj, use_py2=False, use_64bits=False):
     """copy raw launcher exe to given file object"""
     if use_py2:
-        filename = 'launcher27.exe'
         if use_64bits:
-            raise ValueError('64 bit support for Python 2.7 currently not implemented')
+            filename = 'launcher27-64.exe'
+        else:
+            filename = 'launcher27-32.exe'
     else:
         if use_64bits:
             filename = 'launcher3-64.exe'

--- a/launcher_tool/create_python27_minimal.py
+++ b/launcher_tool/create_python27_minimal.py
@@ -33,10 +33,17 @@ def copy_python(destination):
     if not os.path.exists(destination):
         os.makedirs(destination)
 
-    for name in ('python.exe', 'pythonw.exe', 'w9xpopen.exe', 'README.txt',
+    for name in ('python.exe', 'pythonw.exe', 'README.txt',
                  'NEWS.txt', 'LICENSE.txt'):
         shutil.copy2(os.path.join(python_source, name),
                      os.path.join(destination, name))
+    try: 
+        # w9xpopen.exe only exists on python27 32bit
+        name = 'w9xpopen.exe'
+        shutil.copy2(os.path.join(python_source, name),
+                     os.path.join(destination, name))
+    except IOError:
+        pass
 
     dll_excludes = ('tcl85.dll', 'tclpip85.dll', 'tk85.dll', '_tkinter.pyd')
     for name in os.listdir(os.path.join(python_source, 'DLLs')):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author_email="cliechti@gmx.net",
     url="https://github.com/zsquareplusc/python-embedded-launcher",
     packages=['launcher_tool'],
-    package_data={'launcher_tool': ['launcher27.exe', 'launcher3-32.exe', 'launcher3-64.exe']},
+    package_data={'launcher_tool': ['launcher27-32.exe', 'launcher27-32.exe', 'launcher3-32.exe', 'launcher3-64.exe']},
     license="BSD",
     long_description=open('README.rst').read(),
     entry_points={

--- a/src/python27/compile.bat
+++ b/src/python27/compile.bat
@@ -1,5 +1,13 @@
-@set PATH=C:\TDM-GCC-32\bin;%PATH%
-@for /f %%i in ('python -c "import sys,os; print(os.path.dirname(sys.executable))"') do set PY2_INC=%%i
-windres -F pe-i386 launcher27.rc -O coff -o launcher27.res
-gcc -m32 -o ..\..\launcher_tool\launcher27.exe launcher27.c launcher27.res -Wall -I %PY2_INC%\\include
-strip ..\..\launcher_tool\launcher27.exe
+set PY2_64_INC=C:\Python27
+set PY2_32_INC=C:\Python27-32
+
+echo %PY2_64_INC%
+echo %PY2_32_INC%
+
+windres -F pe-i386 launcher27.rc -O coff -o launcher27-32.res
+gcc -m32 -o ..\..\launcher_tool\launcher27-32.exe launcher27.c launcher27-32.res -std=gnu99 -Wall -I %PY2_32_INC%\\include
+strip ..\..\launcher_tool\launcher27-32.exe 
+
+windres -F pe-x86-64 launcher27.rc -O coff -o launcher27-64.res
+gcc -m64 -o ..\..\launcher_tool\launcher27-64.exe launcher27.c launcher27-64.res -std=gnu99 -Wall -I %PY2_64_INC%\\include
+strip ..\..\launcher_tool\launcher27-64.exe


### PR DESCRIPTION
Hi, I like this tool, but I really needed python27 64 bit support. I have compiled and attached the launcher for python2.7 in 64 bit, and updated the code where needed. Also, launcher27.exe should then be renamed to launder27-32.exe

[launcher27-64.zip](https://github.com/zsquareplusc/python-embedded-launcher/files/719131/launcher27-64.zip)

